### PR TITLE
src/httpd: Use mime crate for content types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "jail 0.0.7-alpha.0 (git+https://github.com/fubarnetes/libjail-rs.git?branch=dev)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rctl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ features = ["vec_map"]
 git = "https://github.com/fubarnetes/libjail-rs.git"
 branch = "dev"
 
+[dependencies.mime]
+version = "0.3"
+default-features = false
+
 [dependencies.prometheus]
 version = "0.6"
 default-features = false

--- a/src/httpd/handlers.rs
+++ b/src/httpd/handlers.rs
@@ -82,7 +82,11 @@ mod tests {
         assert_eq!(response.status(), http::StatusCode::OK);
 
         let headers = response.headers();
-        let content_type = headers.get(CONTENT_TYPE).unwrap();
+        let content_type = headers
+            .get(CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
         assert_eq!(content_type, TEXT_HTML_UTF_8);
 
         let bytes = server.execute(response.body()).unwrap();

--- a/src/httpd/handlers.rs
+++ b/src/httpd/handlers.rs
@@ -10,6 +10,10 @@ use actix_web::{
 };
 use actix_web::http::header::CONTENT_TYPE;
 use log::debug;
+use mime::{
+    TEXT_HTML_UTF_8,
+    TEXT_PLAIN_UTF_8,
+};
 
 use super::AppState;
 
@@ -21,7 +25,7 @@ pub(in crate::httpd) fn index(req: &HttpRequest<AppState>) -> HttpResponse {
     let body = &(req.state().index_page);
 
     HttpResponse::Ok()
-        .header(CONTENT_TYPE, "text/html; charset=utf-8")
+        .header(CONTENT_TYPE, TEXT_HTML_UTF_8)
         .body(body)
 }
 
@@ -37,12 +41,12 @@ pub(in crate::httpd) fn metrics(req: &HttpRequest<AppState>) -> HttpResponse {
     match exporter.export() {
         Ok(o) => {
             HttpResponse::Ok()
-                .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+                .header(CONTENT_TYPE, TEXT_PLAIN_UTF_8)
                 .body(o)
         },
         Err(e) => {
             HttpResponse::InternalServerError()
-                .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+                .header(CONTENT_TYPE, TEXT_PLAIN_UTF_8)
                 .body(format!("{}", e))
         },
     }
@@ -79,7 +83,7 @@ mod tests {
 
         let headers = response.headers();
         let content_type = headers.get(CONTENT_TYPE).unwrap();
-        assert_eq!(content_type, "text/html; charset=utf-8");
+        assert_eq!(content_type, TEXT_HTML_UTF_8);
 
         let bytes = server.execute(response.body()).unwrap();
         let body = str::from_utf8(&bytes).unwrap();


### PR DESCRIPTION
Resolves #26 by using the `mime` crate for content types.
Not merging until the `type_length_limit` issue is fixed and tests work again.