### PR TITLE
Use jail 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,8 +611,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jail"
-version = "0.0.7-alpha.0"
-source = "git+https://github.com/fubarnetes/libjail-rs.git?branch=dev#5653915df68c129e56316649b4494b8ad5e840ef"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,7 +636,7 @@ dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "indoc 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jail 0.0.7-alpha.0 (git+https://github.com/fubarnetes/libjail-rs.git?branch=dev)",
+ "jail 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1933,7 +1933,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum jail 0.0.7-alpha.0 (git+https://github.com/fubarnetes/libjail-rs.git?branch=dev)" = "<none>"
+"checksum jail 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "391c5f944adbd86e6736b9c4d496323c7ab70b9ef5ca000301e5abf25a2ce456"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ keywords = [
 askama = "0.8"
 env_logger = "0.6"
 failure = "0.1"
+jail = "0.1.0"
 log = "0.4"
 rctl = "0.1.0"
 
@@ -31,10 +32,6 @@ default-features = false
 version = "2.32"
 default-features = false
 features = ["vec_map"]
-
-[dependencies.jail]
-git = "https://github.com/fubarnetes/libjail-rs.git"
-branch = "dev"
 
 [dependencies.mime]
 version = "0.3"


### PR DESCRIPTION
Now that #29 is fixed in `jail` v0.1.0, you do no longer need to use the `dev` branch (#30)