### PR TITLE
Add file/stdout output mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ## UPCOMING
 
   - Update to [prometheus] 0.7.0.
-  - Update to [actix-web] 1.0.2.
+  - Update to [actix-web] 1.0.8.
+  - Update to [jail] 0.1.1.
   - Bump minimum version of Rust to 1.34.0 in README, due to actix-web update.
+  - Add `output.file-path` argument which allows writing metrics to either a
+    file or stdout.
+  - Internals: Move CLI parsing functions to `cli.rs`.
 
 ## v0.9.10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rctl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1316,6 +1317,14 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1541,19 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2055,6 +2077,7 @@ dependencies = [
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -2082,6 +2105,7 @@ dependencies = [
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 "checksum sysctl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb9e8487a3035580dd12fe86478ad678439eba3c99b170fafc95101e435a9968"
 "checksum sysctl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0501f0d0c2aa64b419abff97c209f4b82c4e67caa63e8dc5b222ecc1b574cb5c"
+"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ failure = "0.1"
 jail = "0.1.1"
 log = "0.4"
 rctl = "0.1.0"
+tempfile = "3.1.0"
 
 [dependencies.actix-web]
 version = "1.0"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ line argument.
 
 Argument             | Default          | Purpose
 ---------------------|------------------|--------
+`output.file-path`   | N/A              | Output metrics to a file instead of running an HTTPd.
 `web.listen-address` | `127.0.0.1:9452` | Address on which to expose metrics and web interface.
 `web.telemetry-path` | `/metrics`       | Path under which to expose metrics.
 
@@ -43,6 +44,7 @@ Argument             | Default          | Purpose
 
 Variable                           | Equivalent Argument
 -----------------------------------|--------------------
+`JAIL_EXPORTER_OUTPUT_FILE_PATH`   | `output.file-path`
 `JAIL_EXPORTER_WEB_LISTEN_ADDRESS` | `web.listen-address`
 `JAIL_EXPORTER_WEB_TELEMETRY_PATH` | `web.telemetry-path`
 
@@ -57,9 +59,14 @@ time series that the exporter exports.  If you wish to account for resource
 usage for jails that have disappeared, you may wish to make use of the
 Prometheus [recording rules] to track total resource usage across all jails.
 
-The exporter will not daemonize itself, instead, it is recommended to use a
-tool such as [`daemon(8)`].  See the included [`rc.d/jail_exporter.in`] for an
-example of this.
+The exporter can be run in two different ways. The default way is to run a
+persistent network daemon for Prometheus to scrape. The exporter will not
+daemonize itself, instead, it is recommended to use a tool such as
+[`daemon(8)`].  See the included [`rc.d/jail_exporter.in`] for an example of
+this.
+
+The second way is to simply output the scraped metrics to a text file. This
+mode is designed to be paired with the [`node_exporter`] [Textfile Collector].
 
 No port is available yet, but it should happen soon.
 
@@ -122,12 +129,14 @@ Metric                | Description
 [FreeBSD]: https://www.freebsd.org/
 [Prometheus]: https://prometheus.io/
 [Rust]: https://www.rust-lang.org/
+[Textfile Collector]: https://github.com/prometheus/node_exporter#textfile-collector
 [jail]: https://crates.io/crates/jail
 [metric and label naming]: https://prometheus.io/docs/practices/naming/
 [rctl]: https://crates.io/crates/rctl
 [recording rules]: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
 [`daemon(8)`]: https://www.freebsd.org/cgi/man.cgi?query=daemon&sektion=8
 [`make(1)`]: https://www.freebsd.org/cgi/man.cgi?query=make&sektion=1
+[`node_exporter`]: https://github.com/prometheus/node_exporter
 [`rc.d/jail_exporter.in`]: rc.d/jail_exporter.in
 [`rctl(8)`]: https://www.freebsd.org/cgi/man.cgi?query=rctl&sektion=8
 [`rctl_get_racct(2)`]: https://www.freebsd.org/cgi/man.cgi?query=rctl_get_racct&sektion=2

--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -10,6 +10,7 @@
 .Op Fl Fl help
 .Op Fl Fl version
 .Nm
+.Op Fl Fl output.file-path Ns = Ns Ar path
 .Op Fl Fl web.listen-address Ns = Ns Ar addr:port
 .Op Fl Fl web.telemetry-path Ns = Ns Ar path
 .Sh DESCRIPTION
@@ -21,6 +22,17 @@ The options are as follows:
 Prints help information
 .It Fl V , Fl Fl version
 Prints version information
+.It Fl Fl output.file-path= Ns Ar path
+Specify a
+.Ar path
+to write collected metrics to.
+When
+.Nm
+is given a
+.Ar path
+it will exit immediately after writing the metrics and the HTTPd will not be
+started.
+This option is designed to be paired with the Node Exporter Textfile Collector.
 .It Fl Fl web.listen-address= Ns Ar addr:port
 Specify an
 .Ar addr:port
@@ -92,6 +104,10 @@ can also take its configuration from environment variables.
 In the event that both command line options and environment variables are
 specified, the command line options will win.
 .Bl -tag -width JAIL_EXPORTER_WEB_LISTEN_ADDRESS
+.It Ev JAIL_EXPORTER_OUTPUT_FILE_PATH
+is equivalent to setting the
+.Fl Fl output.file-path
+option.
 .It Ev JAIL_EXPORTER_WEB_LISTEN_ADDRESS
 is equivalent to setting the
 .Fl Fl web.listen-address

--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -22,7 +22,7 @@ The options are as follows:
 Prints help information
 .It Fl V , Fl Fl version
 Prints version information
-.It Fl Fl output.file-path= Ns Ar path
+.It Fl Fl output.file-path Ns = Ns Ar path
 Specify a
 .Ar path
 to write collected metrics to.
@@ -38,7 +38,7 @@ Giving a
 of
 .Dq Cm -
 will output collected metrics to stdout.
-.It Fl Fl web.listen-address= Ns Ar addr:port
+.It Fl Fl web.listen-address Ns = Ns Ar addr:port
 Specify an
 .Ar addr:port
 on which to expose the metrics and web interface.
@@ -48,7 +48,7 @@ If specifying an IPv6
 .Ar addr:port
 the address portion should be enclosed within square brackets, for example:
 .Dq Cm [::1]:9452 .
-.It Fl Fl web.telemetry-path= Ns Ar path
+.It Fl Fl web.telemetry-path Ns = Ns Ar path
 Specify a
 .Ar path
 under which to expose the metrics.

--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -33,6 +33,11 @@ is given a
 it will exit immediately after writing the metrics and the HTTPd will not be
 started.
 This option is designed to be paired with the Node Exporter Textfile Collector.
+Giving a
+.Ar path
+of
+.Dq Cm -
+will output collected metrics to stdout.
 .It Fl Fl web.listen-address= Ns Ar addr:port
 Specify an
 .Ar addr:port

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,52 @@ use clap::{
 };
 use log::debug;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::str::FromStr;
+
+// Basic checks for valid filesystem path
+fn is_valid_filesystem_path(s: String) -> Result<(), String> {
+    debug!("Ensuring that output.file-path is valid");
+
+    // Get a Path from our string and start checking
+    let path = Path::new(&s);
+
+    // We only take absolute paths
+    if !path.is_absolute() {
+        return Err("output.file-path only accepts absolute paths".to_owned());
+    }
+
+    // We can't write to a directory
+    if path.is_dir() {
+        return Err("output.file-path must not point at a directory".to_owned());
+    }
+
+    // Node Exporter textfiles must end with .prom
+    if let Some(ext) = path.extension() {
+        // Got an extension, ensure that it's .prom
+        if ext != "prom" {
+            return Err("output.file-path must have .prom extension".to_owned());
+        }
+    }
+    else {
+        // Didn't find an extension at all
+        return Err("output.file-path must have .prom extension".to_owned());
+    }
+
+    // Check that the directory exists
+    if let Some(dir) = path.parent() {
+        // Got a parent directory, ensure it exists
+        if !dir.is_dir() {
+            return Err("output.file-path directory must exist".to_owned());
+        }
+    }
+    else {
+        // Didn't get a parent directory at all
+        return Err("output.file-path directory must exist".to_owned());
+    }
+
+    Ok(())
+}
 
 // Used as a validator for the argument parsing.
 fn is_valid_socket_addr(s: String) -> Result<(), String> {
@@ -56,6 +101,16 @@ fn create_app<'a, 'b>() -> clap::App<'a, 'b> {
         .author(crate_authors!())
         .about(crate_description!())
         .set_term_width(80)
+        .arg(
+            clap::Arg::with_name("OUTPUT_FILE_PATH")
+                .env("JAIL_EXPORTER_OUTPUT_FILE_PATH")
+                .hide_env_values(true)
+                .long("output.file-path")
+                .value_name("FILE")
+                .help("File to output metrics to.")
+                .takes_value(true)
+                .validator(is_valid_filesystem_path)
+        )
         .arg(
             clap::Arg::with_name("WEB_LISTEN_ADDRESS")
                 .env("JAIL_EXPORTER_WEB_LISTEN_ADDRESS")
@@ -213,6 +268,42 @@ mod tests {
 
             assert_eq!(telemetry_path, Some("/test"));
         });
+    }
+
+    #[test]
+    fn is_valid_filesystem_path_absolute_path() {
+        let res = is_valid_filesystem_path("tmp/metrics.prom".into());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn is_valid_filesystem_path_bad_extension() {
+        let res = is_valid_filesystem_path("/tmp/metrics.pram".into());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn is_valid_filesystem_path_bad_parent_dir() {
+        let res = is_valid_filesystem_path("/tmp/nope/metrics.prom".into());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn is_valid_filesystem_path_directory() {
+        let res = is_valid_filesystem_path("/tmp".into());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn is_valid_filesystem_path_no_extension() {
+        let res = is_valid_filesystem_path("/tmp/metrics".into());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn is_valid_filesystem_path_ok() {
+        let res = is_valid_filesystem_path("/tmp/metrics.prom".into());
+        assert!(res.is_ok());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,9 +21,18 @@ fn is_valid_filesystem_path(s: String) -> Result<(), String> {
     // Get a Path from our string and start checking
     let path = Path::new(&s);
 
+    // - is special and is a request for us to output to stdout
+    if path == Path::new("-") {
+        return Ok(())
+    }
+
     // We only take absolute paths
     if !path.is_absolute() {
         return Err("output.file-path only accepts absolute paths".to_owned());
+    }
+
+    if path == Path::new("/") {
+        return Err("output.file-path cannot be /".to_owned());
     }
 
     // We can't write to a directory
@@ -303,6 +312,18 @@ mod tests {
     #[test]
     fn is_valid_filesystem_path_ok() {
         let res = is_valid_filesystem_path("/tmp/metrics.prom".into());
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn is_valid_filesystem_path_root() {
+        let res = is_valid_filesystem_path("/".into());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn is_valid_filesystem_path_stdout() {
+        let res = is_valid_filesystem_path("-".into());
         assert!(res.is_ok());
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,21 +18,17 @@ use std::str::FromStr;
 fn is_valid_filesystem_path(s: String) -> Result<(), String> {
     debug!("Ensuring that output.file-path is valid");
 
-    // Get a Path from our string and start checking
-    let path = Path::new(&s);
-
     // - is special and is a request for us to output to stdout
-    if path == Path::new("-") {
+    if s == "-" {
         return Ok(())
     }
+
+    // Get a Path from our string and start checking
+    let path = Path::new(&s);
 
     // We only take absolute paths
     if !path.is_absolute() {
         return Err("output.file-path only accepts absolute paths".to_owned());
-    }
-
-    if path == Path::new("/") {
-        return Err("output.file-path cannot be /".to_owned());
     }
 
     // We can't write to a directory

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,10 +22,6 @@ pub enum Error {
     #[fail(display = "failed to bind to {}", _0)]
     BindAddress(String),
 
-    /// Raised when issues occur within the file exporter
-    #[fail(display = "error occurred while persisting metrics")]
-    PersistError(#[fail(cause)] tempfile::PersistError),
-
     /// Raised if an io::Error occurs
     #[fail(display = "std::io::Error")]
     IoError(#[fail(cause)] std::io::Error),
@@ -37,6 +33,10 @@ pub enum Error {
     /// Raised if the jail_exporter is not running as root.
     #[fail(display = "jail_exporter must be run as root")]
     NotRunningAsRoot,
+
+    /// Raised when issues occur within the file exporter
+    #[fail(display = "error occurred while persisting metrics")]
+    PersistError(#[fail(cause)] tempfile::PersistError),
 
     /// Raised if there are errors originating within the `prometheus` crate.
     #[fail(display = "error within Prometheus library")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,10 @@ pub enum Error {
     #[fail(display = "failed to bind to {}", _0)]
     BindAddress(String),
 
+    /// Raised when issues occur within the file exporter
+    #[fail(display = "error occurred while persisting metrics")]
+    PersistError(#[fail(cause)] tempfile::PersistError),
+
     /// Raised if an io::Error occurs
     #[fail(display = "std::io::Error")]
     IoError(#[fail(cause)] std::io::Error),
@@ -45,6 +49,10 @@ pub enum Error {
     /// Raised if an `askama` template fails to render.
     #[fail(display = "Failed to render template: {}", _0)]
     RenderTemplate(String),
+
+    /// Raised if there's an issue converting from UTF-8 to String
+    #[fail(display = "Failed to convert UTF-8 to String")]
+    Utf8Error(#[fail(cause)] std::string::FromUtf8Error),
 }
 
 // Implements basic output, allowing the above display strings to be used when
@@ -70,5 +78,17 @@ impl From<jail::JailError> for Error {
 impl From<prometheus::Error> for Error {
     fn from(e: prometheus::Error) -> Self {
         Error::PrometheusError(e)
+    }
+}
+
+impl From<tempfile::PersistError> for Error {
+    fn from(e: tempfile::PersistError) -> Self {
+        Error::PersistError(e)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for Error {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        Error::Utf8Error(e)
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -12,46 +12,49 @@ use std::path::{
 };
 use tempfile::NamedTempFile;
 
+enum Output {
+    File(PathBuf),
+    Stdout,
+}
+
 pub struct FileExporter {
-    parent: PathBuf,
-    path: PathBuf,
+    dest: Output,
 }
 
 impl FileExporter {
     pub fn new(path: &str) -> Self {
-        let path = Path::new(&path);
-
-        // We already vetted the parent in the CLI validator, so unwrap here
-        // should be fine.
-        // A path of "-" will have a parent of "" for some reason. This works
-        // just fine for our purposes.
-        let parent = path.parent().unwrap();
+        // "-" is a special case and has us write to stdout.
+        let output = if path == "-" {
+            Output::Stdout
+        }
+        else {
+            let path = Path::new(&path);
+            Output::File(path.into())
+        };
 
         Self {
-            parent: parent.into(),
-            path:   path.into(),
+            dest: output,
         }
     }
 
     // Handles choosing the correct output type based on path
     fn write(&self, metrics: Vec<u8>) -> Result<(), Error> {
-        if self.path == Path::new("-") {
-            // Output to stdout if requested output path was -
-            io::stdout().write_all(&metrics)?;
-        }
-        else {
-            // Otherwise output to the requested file.
-            // Get a temporary file in the parent path of the file we're
-            // exporting to.
-            // We need to do this since we cannot persist across filesystems.
-            let mut file = NamedTempFile::new_in(&self.parent)?;
+        match &self.dest {
+            Output::Stdout => {
+                io::stdout().write_all(&metrics)?;
+            },
+            Output::File(path) => {
+                // We already vetted the parent in the CLI validator, so unwrap
+                // here should be fine.
+                let parent = path.parent().unwrap();
 
-            // Get a string from our utf8
-            let metrics = String::from_utf8(metrics)?;
-
-            // Write metrics to the file and persist to the final file path.
-            write!(file, "{}", metrics)?;
-            file.persist(&self.path)?;
+                // We do this since we need the temporary file to be on the
+                // same filesystem as the final persisted file.
+                let mut file = NamedTempFile::new_in(&parent)?;
+                let metrics = String::from_utf8(metrics)?;
+                write!(file, "{}", metrics)?;
+                file.persist(&path)?;
+            },
         }
 
         Ok(())

--- a/src/file.rs
+++ b/src/file.rs
@@ -3,6 +3,7 @@
 #![forbid(missing_docs)]
 use crate::errors::Error;
 use jail_exporter::Exporter;
+use log::debug;
 use std::io::{
     self,
     Write,
@@ -26,9 +27,13 @@ impl FileExporter {
     pub fn new(path: &str) -> Self {
         // "-" is a special case and has us write to stdout.
         let output = if path == "-" {
+            debug!("New FileExporter outputting to stdout");
+
             Output::Stdout
         }
         else {
+            debug!("New FileExporter outputting to {}", path);
+
             let path = Path::new(&path);
             Output::File(path.into())
         };
@@ -42,9 +47,13 @@ impl FileExporter {
     fn write(&self, metrics: Vec<u8>) -> Result<(), Error> {
         match &self.dest {
             Output::Stdout => {
+                debug!("Writing metrics to stdout");
+
                 io::stdout().write_all(&metrics)?;
             },
             Output::File(path) => {
+                debug!("Writing metrics to {:?}", path);
+
                 // We already vetted the parent in the CLI validator, so unwrap
                 // here should be fine.
                 let parent = path.parent().unwrap();
@@ -62,6 +71,8 @@ impl FileExporter {
     }
 
     pub fn export(self) -> Result<(), Error> {
+        debug!("Exporting metrics to file");
+
         // Get an exporter and export the metrics.
         let exporter = Exporter::new();
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -2,7 +2,10 @@
 
 use crate::errors::Error;
 use jail_exporter::Exporter;
-use std::io::Write;
+use std::io::{
+    self,
+    Write,
+};
 use std::path::{
     Path,
     PathBuf,
@@ -20,6 +23,8 @@ impl FileExporter {
 
         // We already vetted the parent in the CLI validator, so unwrap here
         // should be fine.
+        // A path of "-" will have a parent of "" for some reason. This works
+        // just fine for our purposes.
         let parent = path.parent().unwrap();
 
         Self {
@@ -28,21 +33,39 @@ impl FileExporter {
         }
     }
 
-    pub fn export(self) -> Result<(), Error> {
-        // Get a temporary file in the parent path of the file we're exporting
-        // to.
-        // We need to do this since we cannot persist across filesystems.
-        let mut file = NamedTempFile::new_in(self.parent)?;
+    // Handles choosing the correct output type based on path
+    fn write(&self, metrics: Vec<u8>) -> Result<(), Error> {
+        if self.path == Path::new("-") {
+            // Output to stdout if requested output path was -
+            io::stdout().write_all(&metrics)?;
+        }
+        else {
+            // Otherwise output to the requested file.
+            // Get a temporary file in the parent path of the file we're
+            // exporting to.
+            // We need to do this since we cannot persist across filesystems.
+            let mut file = NamedTempFile::new_in(&self.parent)?;
 
+            // Get a string from our utf8
+            let metrics = String::from_utf8(metrics)?;
+
+            // Write metrics to the file and persist to the final file path.
+            write!(file, "{}", metrics)?;
+            file.persist(&self.path)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn export(self) -> Result<(), Error> {
         // Get an exporter and export the metrics.
         let exporter = Exporter::new();
 
         // TODO: Fix this unwrap
         let metrics = exporter.export().unwrap();
 
-        // Write metrics to the file and persist to the final file path.
-        write!(file, "{}", String::from_utf8(metrics)?)?;
-        file.persist(self.path)?;
+        // Write metrics
+        self.write(metrics)?;
 
         Ok(())
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,49 @@
+// File exporter
+
+use crate::errors::Error;
+use jail_exporter::Exporter;
+use std::io::Write;
+use std::path::{
+    Path,
+    PathBuf,
+};
+use tempfile::NamedTempFile;
+
+pub struct FileExporter {
+    parent: PathBuf,
+    path: PathBuf,
+}
+
+impl FileExporter {
+    pub fn new(path: &str) -> Self {
+        let path = Path::new(&path);
+
+        // We already vetted the parent in the CLI validator, so unwrap here
+        // should be fine.
+        let parent = path.parent().unwrap();
+
+        Self {
+            parent: parent.into(),
+            path:   path.into(),
+        }
+    }
+
+    pub fn export(self) -> Result<(), Error> {
+        // Get a temporary file in the parent path of the file we're exporting
+        // to.
+        // We need to do this since we cannot persist across filesystems.
+        let mut file = NamedTempFile::new_in(self.parent)?;
+
+        // Get an exporter and export the metrics.
+        let exporter = Exporter::new();
+
+        // TODO: Fix this unwrap
+        let metrics = exporter.export().unwrap();
+
+        // Write metrics to the file and persist to the final file path.
+        write!(file, "{}", String::from_utf8(metrics)?)?;
+        file.persist(self.path)?;
+
+        Ok(())
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,5 +1,6 @@
 // File exporter
-
+#![forbid(unsafe_code)]
+#![forbid(missing_docs)]
 use crate::errors::Error;
 use jail_exporter::Exporter;
 use std::io::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,12 +71,7 @@ fn main() -> Result<(), Error> {
 
     // If an output file was specified, we do that. We will never launch the
     // HTTPd when we're passed an OUTPUT_FILE_PATH.
-    if matches.is_present("OUTPUT_FILE_PATH") {
-        let output_path = match matches.value_of("OUTPUT_FILE_PATH") {
-            None    => Err(Error::ArgNotSet("output.file-path".to_owned())),
-            Some(s) => Ok(s),
-        }?;
-
+    if let Some(output_path) = matches.value_of("OUTPUT_FILE_PATH") {
         debug!("output.file-path: {}", output_path);
 
         let exporter = FileExporter::new(output_path);


### PR DESCRIPTION
Closes #45 

This PR adds a new output mode for `jail_exporter`, allowing the metrics to either be written directly to a file on a filesystem, or output to stdout.
The purpose of this is to allow an administrator to reduce the number of network daemons they have running. The intended way to make use of this mode is to pair it with the "Textfile Collector" of `node_exporter`.