### PR TITLE
HTTP Basic Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
   - Added `rc_script` feature, enabling a `--rc-script` CLI flag which outputs
     the `jail_exporter` [`rc(8)`] script on stdout.
   - Added `auth` feature, enabling HTTP Basic authentication.
-    - Configuration for the HTTP Basic authentication is via a YAML configuration
-      file, the location of the configuration is specified via the
-      `--web.auth-config` CLI argument.
+    - Configuration for the HTTP Basic authentication is via a YAML
+      configuration file, the location of the configuration is specified via
+      the `--web.auth-config` CLI argument.
   - Added `bcrypt` subcommand when compiled with the `auth` feature.
     - This is to assist users when they're enabling HTTP Basic Authentication
       as they may not have tools installed for generating bcrypt hashes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@
   - Added `rc_script` feature, enabling a `--rc-script` CLI flag which outputs
     the `jail_exporter` [`rc(8)`] script on stdout.
   - Added `auth` feature, enabling HTTP Basic authentication.
-    Configuration for the HTTP Basic authentication is via a YAML configuration
-    file, the location of the configuration is specified via the
-    `--web.auth-config` CLI argument.
+    - Configuration for the HTTP Basic authentication is via a YAML configuration
+      file, the location of the configuration is specified via the
+      `--web.auth-config` CLI argument.
+  - Added `bcrypt` subcommand when compiled with the `auth` feature.
+    - This is to assist users when they're enabling HTTP Basic Authentication
+      as they may not have tools installed for generating bcrypt hashes.
 
 ## v0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
   - Change environment variables, removing the `JAIL_EXPORTER_` prefix.
   - Added `rc_script` feature, enabling a `--rc-script` CLI flag which outputs
     the `jail_exporter` [`rc(8)`] script on stdout.
-  - Added `auth` feature, enabling HTTP Basic Authentication via the CLI
-    arguments `--web.auth-password` and `--web.auth-username`.
-    - Note that these CLI arguments could be exposed via `ps(1)` on a
-      multi-user system.
+  - Added `auth` feature, enabling HTTP Basic authentication.
+    Configuration for the HTTP Basic authentication is via a YAML configuration
+    file, the location of the configuration is specified via the
+    `--web.auth-config` CLI argument.
 
 ## v0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@
 ## v0.14.0
 
   - Update dependencies.
-  - The MSRV has been bumped to 1.42.0 as required by [actix-web].
+  - The MSRV has been bumped to 1.44.0 as required by dependencies.
   - Fix some minor [clippy] issues.
   - exporter: Remove a clone from metric bookkeeping.
   - exporter: Avoid using clone when creating exporter metrics struct.
   - Change environment variables, removing the `JAIL_EXPORTER_` prefix.
-  - Added `rc_script` feature enabling a `--rc-script` CLI flag which outputs
+  - Added `rc_script` feature, enabling a `--rc-script` CLI flag which outputs
     the `jail_exporter` [`rc(8)`] script on stdout.
+  - Added `auth` feature, enabling HTTP Basic Authentication via the CLI
+    arguments `--web.auth-password` and `--web.auth-username`.
+    - Note that these CLI arguments could be exposed via `ps(1)` on a
+      multi-user system.
 
 ## v0.13.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dtoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1008,8 @@ dependencies = [
  "prometheus",
  "rctl",
  "rustc_version 0.3.0",
+ "serde",
+ "serde_yaml",
  "tempfile",
  "thiserror",
  "users 0.11.0",
@@ -1665,6 +1673,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971be8f6e4d4a47163b405a3df70d14359186f9ab0f3a3ec37df144ca1ce089f"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -2354,3 +2374,12 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "actix-service",
  "actix-threadpool",
  "actix-utils",
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "bytes",
  "cookie",
@@ -260,6 +260,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-httpauth"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536a75d767c5c2b3e64d3f569621f38ed7609359a0c82d149c88290a6ba41b22"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "base64 0.12.3",
+ "bytes",
+ "futures-util",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,7 +395,7 @@ dependencies = [
  "actix-http",
  "actix-rt",
  "actix-service",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "cfg-if 1.0.0",
  "derive_more",
@@ -415,6 +428,12 @@ name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -970,6 +989,7 @@ version = "0.13.0"
 dependencies = [
  "actix-rt",
  "actix-web",
+ "actix-web-httpauth",
  "askama",
  "clap",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570"
 dependencies = [
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -49,7 +49,7 @@ dependencies = [
  "actix-utils",
  "base64 0.13.0",
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "cookie",
  "copyless",
  "derive_more",
@@ -69,7 +69,7 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "rand 0.7.3",
  "regex",
  "serde",
@@ -87,14 +87,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
 dependencies = [
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
 name = "actix-router"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd1f7dbda1645bf7da33554db60891755f6c01c1b2169e2f4c492098d30c235"
+checksum = "b8be584b3b6c705a18eabc11c4059cf83b255bdd8511673d1d569f4ce40c69de"
 dependencies = [
  "bytestring",
  "http",
@@ -199,7 +199,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "either",
  "futures-channel",
  "futures-sink",
@@ -228,7 +228,7 @@ dependencies = [
  "actix-utils",
  "actix-web-codegen",
  "awc",
- "bytes",
+ "bytes 0.5.6",
  "derive_more",
  "encoding_rs",
  "futures-channel",
@@ -237,7 +237,7 @@ dependencies = [
  "fxhash",
  "log",
  "mime",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "regex",
  "serde",
  "serde_json",
@@ -256,7 +256,7 @@ checksum = "ad26f77093333e0e7c6ffe54ebe3582d908a104e448723eec6d43d08b07143fb"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -268,15 +268,15 @@ dependencies = [
  "actix-service",
  "actix-web",
  "base64 0.12.3",
- "bytes",
+ "bytes 0.5.6",
  "futures-util",
 ]
 
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -330,7 +330,7 @@ checksum = "ca2925c4c290382f9d2fa3d1c1b6a63fa1427099721ecca4749b154cc9c25522"
 dependencies = [
  "askama_shared",
  "proc-macro2 1.0.24",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
  "serde",
- "syn 1.0.56",
+ "syn 1.0.58",
  "toml",
 ]
 
@@ -365,7 +365,7 @@ checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "base64 0.13.0",
- "bytes",
+ "bytes 0.5.6",
  "cfg-if 1.0.0",
  "derive_more",
  "futures-core",
@@ -498,9 +498,9 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
@@ -509,12 +509,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "bytestring"
-version = "0.1.5"
+name = "bytes"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7c05fa5172da78a62d9949d662d2ac89d4cc7355d7b49adee5163f1fb3f363"
+checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+
+[[package]]
+name = "bytestring"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
- "bytes",
+ "bytes 1.0.0",
 ]
 
 [[package]]
@@ -574,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "cookie"
@@ -608,7 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c88d9506e2e9230f6107701b7d8425f4cb3f6df108ec3042a26e936666da5"
 dependencies = [
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -619,7 +625,7 @@ checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -691,7 +697,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -725,7 +731,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
  "synstructure",
 ]
 
@@ -769,9 +775,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -783,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -793,48 +799,48 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -843,7 +849,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.2",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -871,11 +877,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -888,7 +894,7 @@ checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -903,7 +909,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -954,11 +960,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.0",
  "fnv",
  "itoa",
 ]
@@ -1086,7 +1092,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.1",
  "rctl",
- "rustc_version 0.3.0",
+ "rustc_version 0.3.2",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -1131,15 +1137,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -1152,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -1396,11 +1402,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -1411,18 +1417,18 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -1433,9 +1439,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -1541,7 +1547,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -1586,7 +1592,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1638,9 +1644,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1650,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -1690,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c94201b44764d6d1f7e37c15a8289ed55e546c1762c7f1d57f616966e0c181"
+checksum = "397d411cfc34097bdb176984180f7d9980eb161aaf1368ceea96c9834d8f8b85"
 dependencies = [
  "semver 0.11.0",
 ]
@@ -1733,7 +1739,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.1",
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -1744,9 +1750,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
 ]
@@ -1768,7 +1774,7 @@ checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -1842,9 +1848,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -1896,7 +1902,7 @@ dependencies = [
  "quote 1.0.8",
  "serde",
  "serde_derive",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -1912,7 +1918,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -1952,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
@@ -1969,7 +1975,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
  "unicode-xid 0.2.1",
 ]
 
@@ -2063,14 +2069,14 @@ checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
@@ -2086,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
+checksum = "273d3ed44dca264b0d6b3665e8d48fb515042d42466fad93d2a45b90ec4058f7"
 dependencies = [
  "const_fn",
  "libc",
@@ -2119,7 +2125,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
  "standback",
- "syn 1.0.56",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -2143,7 +2149,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "iovec",
  "lazy_static",
@@ -2163,7 +2169,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -2188,7 +2194,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "tracing-core",
 ]
 
@@ -2378,9 +2384,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2403,7 +2409,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -2425,7 +2431,7 @@ checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.56",
+ "syn 1.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +623,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f807b2943dc90f9747497d9d65d7e92472149be0b88bf4ce1201b4ac979c26"
+dependencies = [
+ "console",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +666,12 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1041,6 +1075,7 @@ dependencies = [
  "askama",
  "bcrypt",
  "clap",
+ "dialoguer",
  "env_logger",
  "indoc",
  "jail",
@@ -1952,6 +1987,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,3 +2477,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bcrypt"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d0faafe9e089674fc3efdb311ff5253d445c79d85d1d28bd3ace76d45e7164"
+dependencies = [
+ "base64 0.13.0",
+ "blowfish",
+ "getrandom 0.2.1",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +477,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fa6a061124e37baba002e496d203e23ba3d7b73750be82dbfbc92913048a5b"
+dependencies = [
+ "byteorder",
+ "cipher",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -512,6 +534,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "clap"
@@ -812,7 +843,18 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -997,6 +1039,7 @@ dependencies = [
  "actix-web",
  "actix-web-httpauth",
  "askama",
+ "bcrypt",
  "clap",
  "env_logger",
  "indoc",
@@ -1462,7 +1505,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -1485,7 +1528,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
 ]
 
 [[package]]
@@ -2246,6 +2289,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project 1.0.2",
- "rand",
+ "rand 0.7.3",
  "regex",
  "serde",
  "serde_json",
@@ -403,7 +403,7 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding",
- "rand",
+ "rand 0.7.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1084,6 +1084,7 @@ dependencies = [
  "mime",
  "pretty_assertions",
  "prometheus",
+ "rand 0.8.1",
  "rctl",
  "rustc_version 0.3.0",
  "serde",
@@ -1542,9 +1543,21 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.15",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1554,7 +1567,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1567,12 +1590,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.1",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1971,7 +2012,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2183,7 +2224,7 @@ dependencies = [
  "idna",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.7.3",
  "smallvec",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,10 @@ exclude = [
 ]
 
 [features]
-default = ["rc_script"]
+default = ["auth", "rc_script"]
+
+# Enables HTTP basic authentication
+auth = ["actix-web-httpauth"]
 
 # Adds a CLI option to dump out an rc(8) script, useful for users who install
 # via `cargo install`.
@@ -47,6 +50,10 @@ thiserror = "1.0"
 [dependencies.actix-web]
 version = "3.3.0"
 default-features = false
+
+[dependencies.actix-web-httpauth]
+version = "0.5.0"
+optional = true
 
 [dependencies.clap]
 version = "2.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [
 default = ["auth", "rc_script"]
 
 # Enables HTTP basic authentication
-auth = ["actix-web-httpauth"]
+auth = ["actix-web-httpauth", "serde", "serde_yaml"]
 
 # Adds a CLI option to dump out an rc(8) script, useful for users who install
 # via `cargo install`.
@@ -67,6 +67,14 @@ default-features = false
 [dependencies.prometheus]
 version = "0.11.0"
 default-features = false
+
+[dependencies.serde]
+version = "1.0"
+optional = true
+
+[dependencies.serde_yaml]
+version = "0.8"
+optional = true
 
 [dependencies.users]
 version = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [
 default = ["auth", "rc_script"]
 
 # Enables HTTP basic authentication
-auth = ["actix-web-httpauth", "bcrypt", "serde", "serde_yaml"]
+auth = ["actix-web-httpauth", "bcrypt", "dialoguer", "serde", "serde_yaml"]
 
 # Adds a CLI option to dump out an rc(8) script, useful for users who install
 # via `cargo install`.
@@ -63,6 +63,10 @@ optional = true
 version = "2.33"
 default-features = false
 features = ["vec_map"]
+
+[dependencies.dialoguer]
+version = "0.7"
+optional = true
 
 [dependencies.mime]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ exclude = [
 [features]
 default = [
     "auth",
+    "bcrypt_cmd",
     "rc_script",
 ]
 
@@ -38,10 +39,16 @@ default = [
 auth = [
     "actix-web-httpauth",
     "bcrypt",
-    "dialoguer",
-    "rand",
     "serde",
     "serde_yaml",
+]
+
+# Provides a bcrypt subcommand to assist with hashing passwords for
+# authentication
+bcrypt_cmd = [
+    "bcrypt",
+    "dialoguer",
+    "rand",
 ]
 
 # Adds a CLI option to dump out an rc(8) script, useful for users who install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [
 default = ["auth", "rc_script"]
 
 # Enables HTTP basic authentication
-auth = ["actix-web-httpauth", "serde", "serde_yaml"]
+auth = ["actix-web-httpauth", "bcrypt", "serde", "serde_yaml"]
 
 # Adds a CLI option to dump out an rc(8) script, useful for users who install
 # via `cargo install`.
@@ -53,6 +53,10 @@ default-features = false
 
 [dependencies.actix-web-httpauth]
 version = "0.5.0"
+optional = true
+
+[dependencies.bcrypt]
+version = "0.9"
 optional = true
 
 [dependencies.clap]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,20 @@ exclude = [
 ]
 
 [features]
-default = ["auth", "rc_script"]
+default = [
+    "auth",
+    "rc_script",
+]
 
 # Enables HTTP basic authentication
-auth = ["actix-web-httpauth", "bcrypt", "dialoguer", "serde", "serde_yaml"]
+auth = [
+    "actix-web-httpauth",
+    "bcrypt",
+    "dialoguer",
+    "rand",
+    "serde",
+    "serde_yaml",
+]
 
 # Adds a CLI option to dump out an rc(8) script, useful for users who install
 # via `cargo install`.
@@ -75,6 +85,10 @@ default-features = false
 [dependencies.prometheus]
 version = "0.11.0"
 default-features = false
+
+[dependencies.rand]
+version = "0.8"
+optional = true
 
 [dependencies.serde]
 version = "1.0"

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ line argument.
 Argument             | Default          | Purpose
 ---------------------|------------------|--------
 `output.file-path`   | N/A              | Output metrics to a file instead of running an HTTPd.
-`web.auth-password`  | N/A              | Password for HTTP Basic Auth user.
-`web.auth-username   | N/A              | Username for HTTP Basic Auth user.
+`web.auth-config`    | N/A              | HTTP Basic authentication configuration file.
 `web.listen-address` | `127.0.0.1:9452` | Address on which to expose metrics and web interface.
 `web.telemetry-path` | `/metrics`       | Path under which to expose metrics.
 
@@ -87,10 +86,30 @@ Argument             | Default          | Purpose
 Variable             | Equivalent Argument
 ---------------------|--------------------
 `OUTPUT_FILE_PATH`   | `output.file-path`
-`WEB_AUTH_PASSWORD`  | `web.auth-password`
-`WEB_AUTH_USERNAME`  | `web.auth-username`
+`WEB_AUTH_CONFIG  `  | `web.auth-config`
 `WEB_LISTEN_ADDRESS` | `web.listen-address`
 `WEB_TELEMETRY_PATH` | `web.telemetry-path`
+
+### HTTP Basic Authentication
+
+HTTP Basic Authentication is available when the crate is compiled with the
+`auth` feature. This feature is enabled by default.
+
+The configuration file format is the same as specified in [`exporter-toolkit`].
+
+```yaml
+---
+basic_auth_users:
+    username: 'some password'
+    another_user: 'good password'
+```
+
+If no configuration is specified, or the configuration is specified but
+contains no users, authentication will be disabled.
+
+While loading the configuration, usernames will be checked for compliance with
+[RFC7617]. If any invalid usernames are detected, `jail_exporter` will error
+out and refuse to start.
 
 ## Running
 
@@ -182,15 +201,10 @@ The `rc_script` feature is enabled by default for the benefit of users
 installing via `cargo install`. It is disabled by default in the FreeBSD port
 as the [`rc(8)`] script is supplied in the ports tree.
 
-The HTTP Basic Authentication is configured via the `--web.auth-password` and
-`--web.auth-username` command line arguments. These arguments may be exposed
-via `ps(1)` depending on the configuration of your system. Measures to prevent
-the leaking of the password should be taken if the exporter metrics are
-considered sensitive.
-
 [Build Status]: https://api.cirrus-ci.com/github/phyber/jail_exporter.svg
 [FreeBSD]: https://www.freebsd.org/
 [Prometheus]: https://prometheus.io/
+[RFC7617]: https://tools.ietf.org/html/rfc7617
 [Rust]: https://www.rust-lang.org/
 [Textfile Collector]: https://github.com/prometheus/node_exporter#textfile-collector
 [crates.io]: https://crates.io/crates/jail_exporter
@@ -199,6 +213,7 @@ considered sensitive.
 [rctl]: https://crates.io/crates/rctl
 [recording rules]: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
 [`daemon(8)`]: https://www.freebsd.org/cgi/man.cgi?query=daemon&sektion=8
+[`exporter-toolkit`]: https://github.com/prometheus/exporter-toolkit
 [`make(1)`]: https://www.freebsd.org/cgi/man.cgi?query=make&sektion=1
 [`node_exporter`]: https://github.com/prometheus/node_exporter
 [`rc(8)`]: https://man.freebsd.org/rc(8)

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The configuration file format is the same as specified in [`exporter-toolkit`].
 ```yaml
 ---
 basic_auth_users:
-    username: 'some password'
-    another_user: 'good password'
+    username: 'bcrypt hashed secret'
+    another_user: 'bcrypt hashed secret'
 ```
 
 If no configuration is specified, or the configuration is specified but
@@ -110,6 +110,19 @@ contains no users, authentication will be disabled.
 While loading the configuration, usernames will be checked for compliance with
 [RFC7617]. If any invalid usernames are detected, `jail_exporter` will error
 out and refuse to start.
+
+User passwords are [bcrypt] hashed secrets, which can be generated with the
+`bcrypt` subcommand.
+
+```shell
+jail_exporter bcrypt foobarpass
+$2b$04$FDs/.p4csWdp8cnPbU6rK.TNvo5OuNx9zd4B0cbujnfleIvzejBYG
+```
+
+The cost for the password hashing can be controlled with the `--cost` argument
+to the `bcrypt` subcommand and defaults to `12`. This default it taken from the
+bcrypt crate and should be tuned for the computer the hashing will be running
+on, as this cost will be paid each time a connection is authenticated.
 
 ## Running
 
@@ -207,6 +220,7 @@ as the [`rc(8)`] script is supplied in the ports tree.
 [RFC7617]: https://tools.ietf.org/html/rfc7617
 [Rust]: https://www.rust-lang.org/
 [Textfile Collector]: https://github.com/prometheus/node_exporter#textfile-collector
+[bcrypt]: https://en.wikipedia.org/wiki/Bcrypt
 [crates.io]: https://crates.io/crates/jail_exporter
 [jail]: https://crates.io/crates/jail
 [metric and label naming]: https://prometheus.io/docs/practices/naming/

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sysrc jail_exporter_enable=YES
 
 At a minimum, building Jail Exporter should require:
 
-  - Rust v1.42.0
+  - Rust v1.44.0
   - Cargo
 
 A BSD [`make(1)`] Makefile is provided for convenience, if you already have
@@ -77,6 +77,8 @@ line argument.
 Argument             | Default          | Purpose
 ---------------------|------------------|--------
 `output.file-path`   | N/A              | Output metrics to a file instead of running an HTTPd.
+`web.auth-password`  | N/A              | Password for HTTP Basic Auth user.
+`web.auth-username   | N/A              | Username for HTTP Basic Auth user.
 `web.listen-address` | `127.0.0.1:9452` | Address on which to expose metrics and web interface.
 `web.telemetry-path` | `/metrics`       | Path under which to expose metrics.
 
@@ -85,6 +87,8 @@ Argument             | Default          | Purpose
 Variable             | Equivalent Argument
 ---------------------|--------------------
 `OUTPUT_FILE_PATH`   | `output.file-path`
+`WEB_AUTH_PASSWORD`  | `web.auth-password`
+`WEB_AUTH_USERNAME`  | `web.auth-username`
 `WEB_LISTEN_ADDRESS` | `web.listen-address`
 `WEB_TELEMETRY_PATH` | `web.telemetry-path`
 
@@ -169,6 +173,7 @@ Metric                | Description
 
 Feature     | Default | Description
 ------------|---------|------------
+`auth`      | `true`  | Enables HTTP Basic Authentication
 `rc_script` | `true`  | Enables the `--rc-script` CLI flag to dump the [`rc(8)`] script to stdout
 
 ## Notes
@@ -176,6 +181,12 @@ Feature     | Default | Description
 The `rc_script` feature is enabled by default for the benefit of users
 installing via `cargo install`. It is disabled by default in the FreeBSD port
 as the [`rc(8)`] script is supplied in the ports tree.
+
+The HTTP Basic Authentication is configured via the `--web.auth-password` and
+`--web.auth-username` command line arguments. These arguments may be exposed
+via `ps(1)` depending on the configuration of your system. Measures to prevent
+the leaking of the password should be taken if the exporter metrics are
+considered sensitive.
 
 [Build Status]: https://api.cirrus-ci.com/github/phyber/jail_exporter.svg
 [FreeBSD]: https://www.freebsd.org/

--- a/README.md
+++ b/README.md
@@ -112,11 +112,25 @@ While loading the configuration, usernames will be checked for compliance with
 out and refuse to start.
 
 User passwords are [bcrypt] hashed secrets, which can be generated with the
-`bcrypt` subcommand.
+`bcrypt` subcommand if `jail_exporter` was compiled with the `bcrypt_cmd`
+feature (enabled by default).
 
 ```shell
-jail_exporter bcrypt foobarpass
-$2b$04$FDs/.p4csWdp8cnPbU6rK.TNvo5OuNx9zd4B0cbujnfleIvzejBYG
+# Generate a password by specifying it on the CLI 
+$ jail_exporter bcrypt foobar
+Hash: $2b$12$kSOSps7NIQaEQi2CXb.Ll.qYQZ3pCK7NDWKUH7QvHzprUyLHL6tsq
+
+# Generate a password via an interactive prompt
+# The password will be prompted for and then confirmed
+$ jail_exporter bcrypt
+Password: [hidden]
+Hash: $2b$12$/5ghhZFShmhrq5W4tE1hnubk/xgGH0MmixxQeKwSGx0g7kjDFL2hq
+
+# Generate a random password
+# The random plaintext password will also be output.
+$ jail_exporter bcrypt --random
+Password: TiFRz4rg6JHdRunnIFm2aB3uNa0OnlU7
+Hash: $2b$12$dyK2iA1Yq1ToA9AWtjg96exmvLABj05DuB1V5a4haUOZvu2.Hvbo2
 ```
 
 The cost for the password hashing can be controlled with the `--cost` argument
@@ -203,10 +217,11 @@ Metric                | Description
 
 ## Crate Features
 
-Feature     | Default | Description
-------------|---------|------------
-`auth`      | `true`  | Enables HTTP Basic Authentication
-`rc_script` | `true`  | Enables the `--rc-script` CLI flag to dump the [`rc(8)`] script to stdout
+Feature      | Default | Description
+-------------|---------|------------
+`auth`       | `true`  | Enables HTTP Basic Authentication
+`bcrypt_cmd` | `true`  | Enables a `bcrypt` subcommand to assist with hashing passwords for HTTP Basic Authentication
+`rc_script`  | `true`  | Enables the `--rc-script` CLI flag to dump the [`rc(8)`] script to stdout
 
 ## Notes
 

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,0 +1,12 @@
+---
+# An example configuration file for HTTP basic authentication
+# Usernames and passwords live under a basic_auth_users key.
+basic_auth_users:
+    # Username are plaintext, excluding control characters and the colon (:)
+    # character. Passwords are bcrypt hashed.
+    bob: '$2b$12$YQEBUkH./t9oZTWqgK5NxeKI7pj/7bxa1Sct5FkplDgcdwWJ1PrRO'
+    foo: '$2b$12$n2uFO.vPTiO3NjEUQ73AA.R4PslDrFmEucF0j5qICJ0525oKYOYGm'
+
+# Any other keys in the file are ignored.
+ignored:
+    sure: 'is'

--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -114,9 +114,6 @@ Defaults to
 Optionally specify a
 .Ar password
 to hash.
-A minimum length of
-.Cm 8
-characters is enforced.
 If a
 .Ar password
 is not specified, it is interactively prompted for.

--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -20,8 +20,9 @@
 .Op Fl Fl random
 .Op Fl Fl cost Ns = Ns Ar cost
 .Op Fl Fl length Ns = Ns Ar length
-.Op Ar PASSWORD
+.Op Ar password
 .Sh DESCRIPTION
+.Ss Command Line Arguments
 .Nm jail_exporter
 is a Prometheus exporter for jail metrics.
 The options are as follows:
@@ -88,7 +89,7 @@ under which to expose the metrics.
 Defaults to
 .Dq Cm /metrics .
 .El
-.Pp
+.Ss Sub-Commands
 .Nm
 also features a
 .Cm bcrypt
@@ -118,6 +119,24 @@ If a
 .Ar password
 is not specified, it is interactively prompted for.
 .El
+.Ss HTTP Basic Authentication Configuration
+HTTP basic authentication is configured via a YAML configuration file.
+The format of this file follows the suggestions of the Prometheus
+exporter-toolkit.
+This authentication configuration consists of a
+.Dq basic_auth_users
+key which is a map of usernames to bcrypt hashed passwords.
+These hashes can be generated with the
+.Nm
+.Cm bcrypt
+sub-command or any other utility capable of generating bcrypt hashes.
+Any keys in the file other than
+.Dq basic_auth_users
+are ignored.
+.Pp
+An example HTTP basic authentication configuration can be found in the
+.Sx EXAMPLES
+section.
 .Sh USAGE
 .Nm
 must be run as
@@ -203,31 +222,27 @@ script
 the exporter daemon
 .El
 .Sh EXAMPLES
-HTTP Basic Authentication.
-This config file is in the YAML format and contains a
-.Dq basic_auth_users
-section which is a map of usernames to bcrypt hashed passwords.
-These hashes can be generated with the
-.Nm
-.Cm bcrypt
-sub-command or any other utility capable of generating bcrypt hashes.
+.Ss HTTP Basic Authentication
+Simple configuration file for two users:
 .Pp
 .Dl ---
 .Dl basic_auth_users:
-.Dl \ \ # foo: foopass
 .Dl \ \ foo: '$2b$12$cGBwrALG2Crkm5jPdvzlG.R8.j8LMeCEecm4y/So6YVd4YiIrfqsW'
-.Dl \ \ # baz: bazpass
 .Dl \ \ bar: '$2b$12$8c6yHGFexzAvbtNSHV3WNO0zJoaWfDy9WqX7s8vCAajV08LE/cW06'
+.Ss Sub-Commands
 .Pp
 Generating a bcrypt password hash by specifying the password on the command
 line using the default bcrypt cost:
-.Dl $ jail_exporter bcrypt foopass1
+.Pp
+.Dl $ jail_exporter bcrypt foopass
 .Pp
 Generating a random bcrypt password hash with an increased cost and custom
 length:
+.Pp
 .Dl $ jail_exporter bcrypt --random --cost 14 --length 48
 .Pp
 Generating a bcrypt password via the interactive prompt:
+.Pp
 .Dl $ jail_exporter bcrypt
 .Sh SEE ALSO
 .Xr rctl 4 ,

--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -12,8 +12,15 @@
 .Op Fl Fl rc-script
 .Nm
 .Op Fl Fl output.file-path Ns = Ns Ar path
+.Op Fl Fl web.auth-config Ns = Ns Ar path
 .Op Fl Fl web.listen-address Ns = Ns Ar addr:port
 .Op Fl Fl web.telemetry-path Ns = Ns Ar path
+.Nm
+.Cm bcrypt
+.Op Fl Fl random
+.Op Fl Fl cost Ns = Ns Ar cost
+.Op Fl Fl length Ns = Ns Ar length
+.Op Ar PASSWORD
 .Sh DESCRIPTION
 .Nm jail_exporter
 is a Prometheus exporter for jail metrics.
@@ -51,6 +58,19 @@ Giving a
 of
 .Dq Cm -
 will output collected metrics to stdout.
+.It Fl Fl web.auth-config Ns = Ns Ar path
+Specify a
+.Ar path
+to load HTTP Basic Authentication configuration from.
+The configuration is in the YAML format and is documented in the
+.Sx EXAMPLES
+section.
+There is no default location for this configuration file, but a location such
+as
+.Pa /usr/local/etc/jail_exporter.yaml
+or
+.Pa /usr/local/etc/jail_exporter/config.yaml
+is suggested.
 .It Fl Fl web.listen-address Ns = Ns Ar addr:port
 Specify an
 .Ar addr:port
@@ -67,6 +87,39 @@ Specify a
 under which to expose the metrics.
 Defaults to
 .Dq Cm /metrics .
+.El
+.Pp
+.Nm
+also features a
+.Cm bcrypt
+sub-command, useful for hashing the passwords used for HTTP Basic
+authentication.
+This sub-command features the following arguments:
+.Bl -tag -width indent
+.It Fl Fl random
+Generates a random password and outputs both the plaintext and hashed values.
+.It Fl Fl cost Ns = Ns Ar cost
+Specifies the bcrypt
+.Ar cost
+of the hash.
+Defaults to
+.Dq Cm 12 .
+.It Fl Fl length Ns = Ns Ar length
+Specifies the password length to generate when used with the
+.Fl Fl random
+flag.
+Defaults to
+.Dq Cm 32 .
+.It Ar password
+Optionally specify a
+.Ar password
+to hash.
+A minimum length of
+.Cm 8
+characters is enforced.
+If a
+.Ar password
+is not specified, it is interactively prompted for.
 .El
 .Sh USAGE
 .Nm
@@ -130,6 +183,10 @@ specified, the command line options will win.
 is equivalent to setting the
 .Fl Fl output.file-path
 option.
+.It Ev WEB_AUTH_CONFIG
+is equivalent to setting the
+.Fl Fl web.auth-config
+option.
 .It Ev WEB_LISTEN_ADDRESS
 is equivalent to setting the
 .Fl Fl web.listen-address
@@ -148,6 +205,33 @@ script
 .It Pa /usr/local/sbin/jail_exporter
 the exporter daemon
 .El
+.Sh EXAMPLES
+HTTP Basic Authentication.
+This config file is in the YAML format and contains a
+.Dq basic_auth_users
+section which is a map of usernames to bcrypt hashed passwords.
+These hashes can be generated with the
+.Nm
+.Cm bcrypt
+sub-command or any other utility capable of generating bcrypt hashes.
+.Pp
+.Dl ---
+.Dl basic_auth_users:
+.Dl \ \ # foo: foopass
+.Dl \ \ foo: '$2b$12$cGBwrALG2Crkm5jPdvzlG.R8.j8LMeCEecm4y/So6YVd4YiIrfqsW'
+.Dl \ \ # baz: bazpass
+.Dl \ \ bar: '$2b$12$8c6yHGFexzAvbtNSHV3WNO0zJoaWfDy9WqX7s8vCAajV08LE/cW06'
+.Pp
+Generating a bcrypt password hash by specifying the password on the command
+line using the default bcrypt cost:
+.Dl $ jail_exporter bcrypt foopass1
+.Pp
+Generating a random bcrypt password hash with an increased cost and custom
+length:
+.Dl $ jail_exporter bcrypt --random --cost 14 --length 48
+.Pp
+Generating a bcrypt password via the interactive prompt:
+.Dl $ jail_exporter bcrypt
 .Sh SEE ALSO
 .Xr rctl 4 ,
 .Xr loader.conf 5 ,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,6 +192,7 @@ fn create_app<'a, 'b>() -> clap::App<'a, 'b> {
             .arg(
                 clap::Arg::with_name("COST")
                     .long("cost")
+                    .short("c")
                     .value_name("COST")
                     .help("Computes the hash using the given cost")
                     .takes_value(true)
@@ -201,6 +202,7 @@ fn create_app<'a, 'b>() -> clap::App<'a, 'b> {
             .arg(
                 clap::Arg::with_name("RANDOM")
                     .long("random")
+                    .short("r")
                     .help("Generate a random password instead of having to \
                            specify one")
             )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,7 @@ fn is_valid_basic_auth_config_path(s: String) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(feature = "auth")]
+#[cfg(feature = "bcrypt_cmd")]
 // Ensures that a given bcrypt cost is valid
 fn is_valid_bcrypt_cost(s: String) -> Result<(), String> {
     debug!("Ensuring that bcrypt cost is valid");
@@ -172,18 +172,19 @@ fn create_app<'a, 'b>() -> clap::App<'a, 'b> {
         );
 
     #[cfg(feature = "auth")]
-    let app = {
-        let app = app.arg(
-            clap::Arg::with_name("WEB_AUTH_CONFIG")
-                .env("WEB_AUTH_CONFIG")
-                .hide_env_values(true)
-                .long("web.auth-config")
-                .value_name("CONFIG")
-                .help("Path to HTTP Basic Authentication configuration")
-                .takes_value(true)
-                .validator(is_valid_basic_auth_config_path)
-        );
+    let app = app.arg(
+        clap::Arg::with_name("WEB_AUTH_CONFIG")
+            .env("WEB_AUTH_CONFIG")
+            .hide_env_values(true)
+            .long("web.auth-config")
+            .value_name("CONFIG")
+            .help("Path to HTTP Basic Authentication configuration")
+            .takes_value(true)
+            .validator(is_valid_basic_auth_config_path)
+    );
 
+    #[cfg(feature = "bcrypt_cmd")]
+    let app = {
         // The default cost here is copied from the bcrypt::DEFAULT_COST
         // constant.
         let bcrypt = clap::SubCommand::with_name("bcrypt")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -200,9 +200,9 @@ fn create_app<'a, 'b>() -> clap::App<'a, 'b> {
             .arg(
                 clap::Arg::with_name("PASSWORD")
                     .value_name("PASSWORD")
-                    .help("The password to hash using bcrypt")
+                    .help("The password to hash using bcrypt, a prompt is \
+                           provided if this is not specified")
                     .takes_value(true)
-                    .required(true)
             );
 
         let app = app.subcommand(bcrypt);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,6 +198,12 @@ fn create_app<'a, 'b>() -> clap::App<'a, 'b> {
                     .validator(is_valid_bcrypt_cost)
             )
             .arg(
+                clap::Arg::with_name("RANDOM")
+                    .long("random")
+                    .help("Generate a random password instead of having to \
+                           specify one")
+            )
+            .arg(
                 clap::Arg::with_name("PASSWORD")
                     .value_name("PASSWORD")
                     .help("The password to hash using bcrypt, a prompt is \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -139,6 +139,29 @@ fn create_app<'a, 'b>() -> clap::App<'a, 'b> {
                 .validator(is_valid_telemetry_path)
         );
 
+    #[cfg(feature = "auth")]
+    let app = app
+        .arg(
+            clap::Arg::with_name("WEB_AUTH_PASSWORD")
+                .env("WEB_AUTH_PASSWORD")
+                .hide_env_values(true)
+                .long("web.auth-password")
+                .value_name("PASSWORD")
+                .help("Password for HTTP basic authentication")
+                .takes_value(true)
+                .requires("WEB_AUTH_USERNAME")
+        )
+        .arg(
+            clap::Arg::with_name("WEB_AUTH_USERNAME")
+                .env("WEB_AUTH_USERNAME")
+                .hide_env_values(true)
+                .long("web.auth-username")
+                .value_name("USERNAME")
+                .help("Username for authentication")
+                .takes_value(true)
+                .requires("WEB_AUTH_PASSWORD")
+        );
+
     #[cfg(feature = "rc_script")]
     let app = app
         .arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,8 @@ fn is_valid_bcrypt_cost(s: String) -> Result<(), String> {
         Ok(c)  => c,
     };
 
+    // Min and max costs taken from the bcrypt crate. The consts are private so
+    // we can't reference them directly.
     if cost < 4 || cost > 31 {
         return Err("cost cannot be less than 4 or more than 31".to_owned());
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,11 @@ pub enum ExporterError {
     #[error("HttpdError: {0}")]
     HttpdError(#[from] crate::httpd::HttpdError),
 
+    #[cfg(feature = "auth")]
+    /// Raised if a configured username is invalid
+    #[error("Invalid username: {0}")]
+    InvalidUsername(String),
+
     /// Raised if an io::Error occurs
     #[error("std::io::Error")]
     IoError(#[from] std::io::Error),
@@ -45,6 +50,11 @@ pub enum ExporterError {
     /// Raised if there's an issue converting from UTF-8 to String
     #[error("Failed to convert UTF-8 to String")]
     Utf8Error(#[from] std::string::FromUtf8Error),
+
+    #[cfg(feature = "auth")]
+    /// Raised if there is an issue reading the YAML configuration
+    #[error("Failed to read YAML configuration")]
+    YamlError(#[from] serde_yaml::Error),
 }
 
 // There is no as_dyn_error for jail::JailError, so we manually implement From

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,7 +15,7 @@ pub enum ExporterError {
     #[error("{0} was not set.")]
     ArgNotSet(String),
 
-    #[cfg(feature = "auth")]
+    #[cfg(feature = "bcrypt_cmd")]
     /// Raised if there is an error while hashing a password.
     #[error("bcrypt error while hashing password")]
     BcryptHashingError(#[from] bcrypt::BcryptError),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,17 @@ pub enum ExporterError {
     #[error("{0} was not set.")]
     ArgNotSet(String),
 
+    #[cfg(feature = "auth")]
+    /// Raised if there is an error while hashing a password.
+    #[error("bcrypt error while hashing password")]
+    BcryptHashingError(#[from] bcrypt::BcryptError),
+
+    #[cfg(feature = "auth")]
+    /// Raised if there is a problem validating the bcrypt password while
+    /// validating the config.
+    #[error("bcrypt error with password for user: {0}")]
+    BcryptValidationError(String),
+
     #[error("HttpdError: {0}")]
     HttpdError(#[from] crate::httpd::HttpdError),
 

--- a/src/httpd.rs
+++ b/src/httpd.rs
@@ -21,7 +21,9 @@ use actix_web::middleware::Condition;
 #[cfg(feature = "auth")]
 use actix_web_httpauth::middleware::HttpAuthentication;
 
+#[cfg(feature = "auth")]
 mod auth;
+
 mod collector;
 mod errors;
 mod handlers;

--- a/src/httpd.rs
+++ b/src/httpd.rs
@@ -15,6 +15,21 @@ use log::{
     info,
 };
 
+#[cfg(feature = "auth")]
+use actix_web::{
+    dev::ServiceRequest,
+    error::ErrorUnauthorized,
+    middleware::Condition,
+    web::Data,
+    Error,
+};
+
+#[cfg(feature = "auth")]
+use actix_web_httpauth::{
+    extractors::basic::BasicAuth,
+    middleware::HttpAuthentication,
+};
+
 mod collector;
 mod errors;
 mod handlers;
@@ -30,13 +45,73 @@ pub use errors::HttpdError;
 // This AppState is used to pass the rendered index template to the index
 // function.
 pub(self) struct AppState {
-    exporter:   Box<dyn Collector>,
-    index_page: String,
+    #[cfg(feature = "auth")]
+    auth_password: Option<String>,
+
+    #[cfg(feature = "auth")]
+    auth_username: Option<String>,
+
+    exporter:      Box<dyn Collector>,
+    index_page:    String,
+}
+
+#[cfg(feature = "auth")]
+// Validate HTTP Basic auth credentials.
+// Usernames and passwords aren't checked in constant time.
+async fn validate_credentials(
+    req: ServiceRequest,
+    credentials: BasicAuth,
+) -> Result<ServiceRequest, Error> {
+    debug!("Validating credentials");
+
+    let state = req.app_data::<Data<AppState>>()
+        .expect("Missing AppState")
+        .get_ref();
+
+    // These derefs give us an Option<&str> instead of the real
+    // Option<String>, allowing us to compare to the Cow<&str>
+    // easily later on.
+    let auth_password = state.auth_password.as_deref();
+    let auth_username = state.auth_username.as_deref();
+
+    // If the state password or username are None, no
+    // authentication was setup, and we can simply return.
+    if auth_password.is_none() || auth_username.is_none() {
+        debug!("No username or password in AppState, allowing access");
+        return Ok(req);
+    }
+
+    // Username comparson is simple.
+    let user_id = credentials.user_id().as_ref();
+    if Some(user_id) != auth_username {
+        debug!("user_id doesn't match auth_username, denying access");
+        return Err(ErrorUnauthorized("Unauthorized"));
+    };
+
+    // We need to get the reference to the Cow str to compare
+    // passwords properly, so a little unwrapping is necessary
+    let password = match credentials.password() {
+        Some(password) => Some(password.as_ref()),
+        None           => None,
+    };
+
+    if password != auth_password {
+        debug!("password doesn't match auth_password, denying access");
+        return Err(ErrorUnauthorized("Unauthorized"));
+    };
+
+    Ok(req)
 }
 
 // Used for the httpd builder
 #[derive(Debug)]
 pub struct Server {
+    #[cfg(feature = "auth")]
+    auth_password:  Option<String>,
+
+    #[cfg(feature = "auth")]
+    auth_username:  Option<String>,
+
     bind_address:   String,
     telemetry_path: String,
 }
@@ -44,6 +119,12 @@ pub struct Server {
 impl Default for Server {
     fn default() -> Self {
         Self {
+            #[cfg(feature = "auth")]
+            auth_password:  None,
+
+            #[cfg(feature = "auth")]
+            auth_username:  None,
+
             bind_address:   "127.0.0.1:9452".into(),
             telemetry_path: "/metrics".into(),
         }
@@ -55,6 +136,24 @@ impl Server {
     // Returns a new server instance.
     pub fn new() -> Self {
         Default::default()
+    }
+
+    #[cfg(feature = "auth")]
+    // Sets the HTTP basic auth password
+    pub fn auth_password(mut self, password: String) -> Self {
+        debug!("Setting HTTP basic auth password to: {}", password);
+
+        self.auth_password = Some(password);
+        self
+    }
+
+    #[cfg(feature = "auth")]
+    // Sets the HTTP basic auth username
+    pub fn auth_username(mut self, username: String) -> Self {
+        debug!("Setting HTTP basic auth username to: {}", username);
+
+        self.auth_username = Some(username);
+        self
     }
 
     // Sets the bind_address of the server.
@@ -80,20 +179,48 @@ impl Server {
         let index_page     = render_index_page(&self.telemetry_path)?;
         let telemetry_path = self.telemetry_path.clone();
 
+        #[cfg(feature = "auth")]
+        let auth_password = self.auth_password;
+
+        #[cfg(feature = "auth")]
+        let auth_username = self.auth_username;
+
+        #[cfg(feature = "auth")]
+        // This boolean decides if the authentication middleware is enabled in
+        // the wrap condition.
+        let enable_auth = auth_password.is_some() && auth_username.is_some();
+
         // Route handlers
         debug!("Registering HTTP app routes");
         let app = move || {
             // This state is shared between threads and allows us to pass
             // arbitrary items to request handlers.
             let state = AppState {
-                exporter:   exporter.clone(),
-                index_page: index_page.clone(),
+                #[cfg(feature = "auth")]
+                auth_password: auth_password.clone(),
+
+                #[cfg(feature = "auth")]
+                auth_username: auth_username.clone(),
+
+                exporter:      exporter.clone(),
+                index_page:    index_page.clone(),
             };
 
-            actix_web::App::new()
+            // Order is important in the App config.
+            let app = actix_web::App::new()
                 .data(state)
                 // Enable request logging
-                .wrap(Logger::default())
+                .wrap(Logger::default());
+
+            #[cfg(feature = "auth")]
+            // Authentication
+            let app = app.wrap(Condition::new(
+                enable_auth,
+                HttpAuthentication::basic(validate_credentials),
+            ));
+
+            // Finally add routes
+            app
                 // Root of HTTP server. Provides a basic index page and
                 // link to the metrics page.
                 .route("/", web::get().to(index))

--- a/src/httpd.rs
+++ b/src/httpd.rs
@@ -112,13 +112,14 @@ impl Server {
         let telemetry_path = self.telemetry_path.clone();
 
         #[cfg(feature = "auth")]
+        // Unwrap the config if we have one, otherwise use a default.
         let basic_auth_config = match self.basic_auth_config {
             Some(config) => config,
             None         => Default::default(),
         };
 
         // Route handlers
-        debug!("Registering HTTP app routes");
+        debug!("Creating HTTP server app");
         let app = move || {
             // This state is shared between threads and allows us to pass
             // arbitrary items to request handlers.
@@ -139,13 +140,10 @@ impl Server {
             #[cfg(feature = "auth")]
             // Authentication
             let app = {
-                // This boolean decides if the authentication middleware is
-                // enabled in the wrap condition.
-                //let enable = auth_password.is_some() && auth_username.is_some();
-                let enable = basic_auth_config.basic_auth_users.is_some();
-
+                // Only enable the authentication if there are some users to
+                // check.
                 app.wrap(Condition::new(
-                    enable,
+                    basic_auth_config.basic_auth_users.is_some(),
                     HttpAuthentication::basic(auth::validate_credentials),
                 ))
             };

--- a/src/httpd/auth.rs
+++ b/src/httpd/auth.rs
@@ -96,6 +96,8 @@ pub async fn validate_credentials(
     let auth_users = match &auth_config.basic_auth_users {
         Some(users) => users,
         None        => {
+            // We shouldn't end up here, because the middleware should be
+            // disabled if we have no users, but we handle it here anyway.
             debug!("No users defined in auth config, allowing access");
             return Ok(req);
         },
@@ -176,6 +178,15 @@ mod tests {
         let config = BasicAuthConfig::from_yaml(&path);
 
         assert!(config.is_err());
+    }
+
+    // Config is a null auth users entry.
+    #[test]
+    fn basic_user_config_from_yaml_null() {
+        let path = "test-data/config_null.yaml";
+        let config = BasicAuthConfig::from_yaml(&path);
+
+        assert!(config.is_ok());
     }
 
     // Config consists of valid usernames

--- a/src/httpd/auth.rs
+++ b/src/httpd/auth.rs
@@ -22,8 +22,20 @@ use std::io::BufReader;
 use std::path::Path;
 use std::str::FromStr;
 
-// Invalid username characters as defined in RFC7617
-const INVALID_USERNAME_CHARS: &[char] = &[':'];
+// Invalid username characters as defined in RFC7617.
+// 0x00 - 0x1f / 0x7f / :
+const INVALID_USERNAME_CHARS: &[char] = &[
+    // 0x00 - 0x1f
+    '\u{00}', '\u{01}', '\u{02}', '\u{03}', '\u{04}', '\u{05}', '\u{06}',
+    '\u{07}', '\u{08}', '\u{09}', '\u{0a}', '\u{0b}', '\u{0c}', '\u{0d}',
+    '\u{0e}', '\u{0f}', '\u{10}', '\u{11}', '\u{12}', '\u{13}', '\u{14}',
+    '\u{15}', '\u{16}', '\u{17}', '\u{18}', '\u{19}', '\u{1a}', '\u{1b}',
+    '\u{1c}', '\u{1d}', '\u{1e}', '\u{1f}',
+    // 0x7f
+    '\u{7f}',
+    // Colon
+    ':',
+];
 
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct BasicAuthConfig {

--- a/src/httpd/auth.rs
+++ b/src/httpd/auth.rs
@@ -65,8 +65,11 @@ pub async fn validate_credentials(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::httpd::{
+        collector::Collector,
+        errors::HttpdError,
+    };
 
-    #[cfg(feature = "auth")]
     use actix_web::{
         dev::Payload,
         test,

--- a/src/httpd/auth.rs
+++ b/src/httpd/auth.rs
@@ -1,0 +1,138 @@
+//
+// jail_exporter
+//
+// This module deal httpd basic authentication.
+//
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+use super::AppState;
+use log::debug;
+use actix_web::{
+    dev::ServiceRequest,
+    error::ErrorUnauthorized,
+    web::Data,
+    Error,
+};
+use actix_web_httpauth::extractors::basic::BasicAuth;
+
+// Validate HTTP Basic auth credentials.
+// Usernames and passwords aren't checked in constant time.
+pub async fn validate_credentials(
+    req: ServiceRequest,
+    credentials: BasicAuth,
+) -> Result<ServiceRequest, Error> {
+    debug!("Validating credentials");
+
+    let state = req.app_data::<Data<AppState>>()
+        .expect("Missing AppState")
+        .get_ref();
+
+    // These derefs give us an Option<&str> instead of the real
+    // Option<String>, allowing us to compare to the Cow<&str>
+    // easily later on.
+    let auth_password = state.auth_password.as_deref();
+    let auth_username = state.auth_username.as_deref();
+
+    // If the state password or username are None, no
+    // authentication was setup, and we can simply return.
+    if auth_password.is_none() || auth_username.is_none() {
+        debug!("No username or password in AppState, allowing access");
+        return Ok(req);
+    }
+
+    // Username comparson is simple.
+    let user_id = credentials.user_id().as_ref();
+    if Some(user_id) != auth_username {
+        debug!("user_id doesn't match auth_username, denying access");
+        return Err(ErrorUnauthorized("Unauthorized"));
+    };
+
+    // We need to get the reference to the Cow str to compare
+    // passwords properly, so a little unwrapping is necessary
+    let password = match credentials.password() {
+        Some(password) => Some(password.as_ref()),
+        None           => None,
+    };
+
+    if password != auth_password {
+        debug!("password doesn't match auth_password, denying access");
+        return Err(ErrorUnauthorized("Unauthorized"));
+    };
+
+    Ok(req)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "auth")]
+    use actix_web::{
+        dev::Payload,
+        test,
+        FromRequest,
+    };
+
+    struct TestCollector;
+    impl Collector for TestCollector {
+        fn collect(&self) -> Result<Vec<u8>, HttpdError> {
+            Ok("collector".as_bytes().to_vec())
+        }
+    }
+
+    #[cfg(feature = "auth")]
+    #[actix_rt::test]
+    async fn validate_credentials_ok() {
+        let exporter = Box::new(TestCollector);
+
+        let data = AppState {
+            auth_password: Some("bar".into()),
+            auth_username: Some("foo".into()),
+            exporter:      exporter,
+            index_page:    "test".into(),
+        };
+
+        // HTTP request using Basic auth with username "foo" password "bar"
+        let req = test::TestRequest::get()
+            .data(data)
+            .header("Authorization", "Basic Zm9vOmJhcg==")
+            .to_http_request();
+
+        let credentials = BasicAuth::from_request(&req, &mut Payload::None)
+            .await
+            .unwrap();
+
+        let req = ServiceRequest::from_request(req).unwrap();
+        let res = validate_credentials(req, credentials).await;
+
+        assert!(res.is_ok());
+    }
+
+    #[cfg(feature = "auth")]
+    #[actix_rt::test]
+    async fn validate_credentials_unauthorized() {
+        let exporter = Box::new(TestCollector);
+
+        let data = AppState {
+            auth_password: Some("bar".into()),
+            auth_username: Some("foo".into()),
+            exporter:      exporter,
+            index_page:    "test".into(),
+        };
+
+        // HTTP request using Basic auth with username "bad" password "password"
+        let req = test::TestRequest::get()
+            .data(data)
+            .header("Authorization", "Basic YmFkOnBhc3N3b3Jk")
+            .to_http_request();
+
+        let credentials = BasicAuth::from_request(&req, &mut Payload::None)
+            .await
+            .unwrap();
+
+        let req = ServiceRequest::from_request(req).unwrap();
+        let res = validate_credentials(req, credentials).await;
+
+        assert!(res.is_err());
+    }
+}

--- a/src/httpd/auth.rs
+++ b/src/httpd/auth.rs
@@ -24,13 +24,18 @@ use std::str::FromStr;
 
 // Invalid username characters as defined in RFC7617.
 // 0x00 - 0x1f / 0x7f / :
+// These are split up to hopefully make the set easier for a human to validate
 const INVALID_USERNAME_CHARS: &[char] = &[
-    // 0x00 - 0x1f
-    '\u{00}', '\u{01}', '\u{02}', '\u{03}', '\u{04}', '\u{05}', '\u{06}',
-    '\u{07}', '\u{08}', '\u{09}', '\u{0a}', '\u{0b}', '\u{0c}', '\u{0d}',
-    '\u{0e}', '\u{0f}', '\u{10}', '\u{11}', '\u{12}', '\u{13}', '\u{14}',
-    '\u{15}', '\u{16}', '\u{17}', '\u{18}', '\u{19}', '\u{1a}', '\u{1b}',
-    '\u{1c}', '\u{1d}', '\u{1e}', '\u{1f}',
+    // 0x00 - 0x09
+    '\u{00}', '\u{01}', '\u{02}', '\u{03}', '\u{04}', '\u{05}',
+    '\u{06}', '\u{07}', '\u{08}', '\u{09}',
+    // 0x0a - 0x0f
+    '\u{0a}', '\u{0b}', '\u{0c}', '\u{0d}', '\u{0e}', '\u{0f}',
+    // 0x10 - 0x19
+    '\u{10}', '\u{11}', '\u{12}', '\u{13}', '\u{14}', '\u{15}',
+    '\u{16}', '\u{17}', '\u{18}', '\u{19}',
+    // 0x1a - 0x1f
+    '\u{1a}', '\u{1b}', '\u{1c}', '\u{1d}', '\u{1e}', '\u{1f}',
     // 0x7f
     '\u{7f}',
     // Colon

--- a/src/httpd/handlers.rs
+++ b/src/httpd/handlers.rs
@@ -69,6 +69,12 @@ mod tests {
         let exporter = Box::new(Exporter::new());
 
         let state = AppState {
+            #[cfg(feature = "auth")]
+            auth_password: None,
+
+            #[cfg(feature = "auth")]
+            auth_username: None,
+
             exporter:   exporter.clone(),
             index_page: "Test Body".into(),
         };

--- a/src/httpd/handlers.rs
+++ b/src/httpd/handlers.rs
@@ -69,14 +69,11 @@ mod tests {
         let exporter = Box::new(Exporter::new());
 
         let state = AppState {
-            #[cfg(feature = "auth")]
-            auth_password: None,
-
-            #[cfg(feature = "auth")]
-            auth_username: None,
-
             exporter:   exporter.clone(),
             index_page: "Test Body".into(),
+
+            #[cfg(feature = "auth")]
+            basic_auth_config: Default::default(),
         };
 
         let data = Data::new(state);

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,23 @@ async fn main() -> Result<(), ExporterError> {
         ::std::process::exit(0);
     }
 
+    #[cfg(feature = "auth")]
+    // If we have the auth feature, we can bcrypt passwords for the user.
+    if let Some(cmd) = matches.subcommand_matches("bcrypt") {
+        // Cost argument is validated and has a default, we can unwrap right
+        // away.
+        let cost = cmd.value_of("COST").unwrap();
+        let cost: u32 = cost.parse().unwrap();
+
+        // Password argument is required, unwrap is safe.
+        let password = cmd.value_of("PASSWORD").unwrap();
+        let hash = bcrypt::hash(password, cost)?;
+
+        println!("{}", hash);
+
+        ::std::process::exit(0);
+    }
+
     // Root is required beyond this point.
     // Check that we're running as root.
     is_running_as_root(&mut UsersCache::new())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@ use errors::ExporterError;
 use exporter::Exporter;
 use file::FileExporter;
 
+#[cfg(feature = "auth")]
+use httpd::auth::BasicAuthConfig;
+
 #[macro_use]
 mod macros;
 
@@ -141,20 +144,10 @@ async fn main() -> Result<(), ExporterError> {
     #[cfg(feature = "auth")]
     // Get and set the username and password for HTTP Basic Auth
     {
-        let auth_password = matches.value_of("WEB_AUTH_PASSWORD");
-        let auth_username = matches.value_of("WEB_AUTH_USERNAME");
+        if let Some(path) = matches.value_of("WEB_AUTH_CONFIG") {
+            let config = BasicAuthConfig::from_yaml(&path)?;
 
-        // CLI validation should have already ensured that both of these are
-        // set, but check again.
-        if auth_password.is_some() && auth_username.is_some() {
-            debug!("Setting username and password for server");
-
-            let auth_password = auth_password.unwrap().to_string();
-            let auth_username = auth_username.unwrap().to_string();
-
-            server = server
-                .auth_password(auth_password)
-                .auth_username(auth_username);
+            server = server.auth_config(config);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,7 +214,7 @@ async fn main() -> Result<(), ExporterError> {
         .telemetry_path(telemetry_path);
 
     #[cfg(feature = "auth")]
-    // Get and set the username and password for HTTP Basic Auth
+    // Set the configuration file for HTTP Basic Auth
     {
         if let Some(path) = matches.value_of("WEB_AUTH_CONFIG") {
             let config = BasicAuthConfig::from_yaml(&path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,13 +110,26 @@ fn bcrypt_cmd(matches: &clap::ArgMatches) -> Result<(), ExporterError> {
                     .collect()
             }
             else {
-                Password::new()
+                let password = Password::new()
                     .with_prompt("Password")
                     .with_confirmation(
                         "Confirm password",
                         "Password mismatch",
                     )
-                    .interact()?
+                    .interact()?;
+
+                let length = password.chars().count();
+
+                if length < cli::MINIMUM_PASSWORD_LENGTH {
+                    eprintln!(
+                        "password must be at least {} characters",
+                        cli::MINIMUM_PASSWORD_LENGTH,
+                    );
+
+                    ::std::process::exit(1);
+                }
+
+                password
             }
         },
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,8 +111,10 @@ async fn main() -> Result<(), ExporterError> {
     if let Some(cmd) = matches.subcommand_matches("bcrypt") {
         // Cost argument is validated and has a default, we can unwrap right
         // away.
-        let cost = cmd.value_of("COST").unwrap();
-        let cost: u32 = cost.parse().unwrap();
+        let cost: u32 = cmd.value_of("COST")
+            .unwrap()
+            .parse()
+            .unwrap();
         let random = cmd.is_present("RANDOM");
 
         // Password argument is required, unwrap is safe.
@@ -120,13 +122,18 @@ async fn main() -> Result<(), ExporterError> {
             Some(password) => password.into(),
             None           => {
                 if random {
-                    let password = thread_rng()
-                        .sample_iter(&Alphanumeric)
-                        .take(32)
-                        .map(char::from)
-                        .collect();
+                    // length was validated by the CLI, we should be safe to
+                    // unwrap and parse to usize here.
+                    let length: usize = cmd.value_of("LENGTH")
+                        .unwrap()
+                        .parse()
+                        .unwrap();
 
-                    password
+                    thread_rng()
+                        .sample_iter(&Alphanumeric)
+                        .take(length)
+                        .map(char::from)
+                        .collect()
                 }
                 else {
                     Password::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ use exporter::Exporter;
 use file::FileExporter;
 
 #[cfg(feature = "auth")]
+use dialoguer::Password;
+
+#[cfg(feature = "auth")]
 use httpd::auth::BasicAuthConfig;
 
 #[macro_use]
@@ -105,7 +108,16 @@ async fn main() -> Result<(), ExporterError> {
         let cost: u32 = cost.parse().unwrap();
 
         // Password argument is required, unwrap is safe.
-        let password = cmd.value_of("PASSWORD").unwrap();
+        let password = match cmd.value_of("PASSWORD") {
+            Some(password) => password.into(),
+            None           => {
+                Password::new()
+                    .with_prompt("Password")
+                    .with_confirmation("Confirm password", "Password mismatch")
+                    .interact()?
+            },
+        };
+
         let hash = bcrypt::hash(password, cost)?;
 
         println!("{}", hash);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,13 +21,13 @@ use errors::ExporterError;
 use exporter::Exporter;
 use file::FileExporter;
 
-#[cfg(feature = "auth")]
+#[cfg(feature = "bcrypt_cmd")]
 use dialoguer::Password;
 
 #[cfg(feature = "auth")]
 use httpd::auth::BasicAuthConfig;
 
-#[cfg(feature = "auth")]
+#[cfg(feature = "bcrypt_cmd")]
 use rand::{
     distributions::Alphanumeric,
     thread_rng,
@@ -106,7 +106,7 @@ async fn main() -> Result<(), ExporterError> {
         ::std::process::exit(0);
     }
 
-    #[cfg(feature = "auth")]
+    #[cfg(feature = "bcrypt_cmd")]
     // If we have the auth feature, we can bcrypt passwords for the user.
     if let Some(cmd) = matches.subcommand_matches("bcrypt") {
         // Cost argument is validated and has a default, we can unwrap right

--- a/test-data/config_invalid.yaml
+++ b/test-data/config_invalid.yaml
@@ -1,0 +1,3 @@
+---
+basic_auth_users:
+    foo:foo: 'bar'

--- a/test-data/config_null.yaml
+++ b/test-data/config_null.yaml
@@ -1,0 +1,2 @@
+---
+basic_auth_users: ~

--- a/test-data/config_ok.yaml
+++ b/test-data/config_ok.yaml
@@ -1,4 +1,4 @@
 ---
 basic_auth_users:
-    foo: 'bar'
-    baz: 'daz'
+    foo: '$2b$04$nFPE4cwFjOFGUmdp.o2NTuh/blJDaEwikX1qoitVe144TsS2l5whS' # baz
+    baz: '$2b$04$dFgE.8scUuR9idW7KBEVGulT4KITuBF58a8y1kztHVrYGV8cGJjZe' # daz

--- a/test-data/config_ok.yaml
+++ b/test-data/config_ok.yaml
@@ -2,3 +2,5 @@
 basic_auth_users:
     foo: '$2b$04$nFPE4cwFjOFGUmdp.o2NTuh/blJDaEwikX1qoitVe144TsS2l5whS' # baz
     baz: '$2b$04$dFgE.8scUuR9idW7KBEVGulT4KITuBF58a8y1kztHVrYGV8cGJjZe' # daz
+other:
+    ignored: 'section'

--- a/test-data/config_ok.yaml
+++ b/test-data/config_ok.yaml
@@ -1,0 +1,4 @@
+---
+basic_auth_users:
+    foo: 'bar'
+    baz: 'daz'


### PR DESCRIPTION
Closes #21 

This PR adds HTTP Basic Authentication. The configuration is handled via a YAML configuration file, following the style set out in the [`exporter-toolkit`](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md).

We also add a `bcrypt` sub-command to assist with generating the necessary bcrypt hashes in case no other tools are installed to generate them.

These features are behind the following feature flags:
  - `auth`: Enables HTTP Basic Authentication
  - `bcrypt_cmd`: Enables the bcrypt sub-command

These features are on by default.