### PR TITLE
fix man page explanation on enabling 'racct'

### DIFF
--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -148,7 +148,7 @@ Although
 .Fx
 ships with RACCT/RCTL support in the kernel, it is disabled by default.
 It can be enabled by setting
-.Va kern.racct.enabled Ns = Ns Qq Ar 1
+.Va kern.racct.enable Ns = Ns Qq Ar 1
 in
 .Pa /boot/loader.conf .
 After setting this, a reboot will be required to enable RACCT/RCTL.


### PR DESCRIPTION
I copied the explanation in the man page to /boot/loader.conf and it did not work.
After 2 reboots I noticed that _kern.racct.enabled="1"_ is not correct and I should write _kern.racct.enable="1"_ instead.