### PR TITLE
Fix FreeBSD image name in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@ task:
     name: 'Cargo Test'
     freebsd_instance:
         matrix:
-            - image: 'freebsd-14-0-release-amd64'
-            - image: 'freebsd-13-2-release-amd64'
+            - image: 'freebsd-14-1-release-amd64-ufs'
+            - image: 'freebsd-13-4-release-amd64'
     env:
         CARGO_HOME: '${HOME}/.cargo'
         CIRRUS_SHELL: '/bin/sh'


### PR DESCRIPTION
Beginning with 14.0, the GCE images have either "ufs" or "zfs" in the name.