### PR TITLE
cli: Fix --web.auth.config CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `jail_exporter`
 
+## Upcoming
+
+  - Fix `--web.auth.config` argument
+    - The old `--web.auth-config` argument did not match what other exporters
+      were doing, which could be confusing. The old argument is now a hidden
+      alias for `--web.auth.config`, so this is not a breaking change
+  - Fix error messages by including the clap `error-context` feature
+  - Minor fixes to tests when not using default crate features
+
 ## v0.18.0
 
   - Update MSRV to 1.85.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ default-features = false
 features = [
     "cargo",
     "env",
+    "error-context",
     "std",
     "wrap_help",
 ]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Argument               | Default          | Purpose
 -----------------------|------------------|--------
 `--output.file-path`   | N/A              | Output metrics to a file instead of running an HTTPd.
 `--rc-script`          | N/A              | Output an appropriate rc.d script
-`--web.auth-config`    | N/A              | HTTP Basic authentication configuration file.
+`--web.auth.config`    | N/A              | HTTP Basic authentication configuration file.
 `--web.listen-address` | `127.0.0.1:9452` | Address on which to expose metrics and web interface.
 `--web.telemetry-path` | `/metrics`       | Path under which to expose metrics.
 
@@ -87,7 +87,7 @@ Argument               | Default          | Purpose
 Variable             | Equivalent Argument
 ---------------------|--------------------
 `OUTPUT_FILE_PATH`   | `output.file-path`
-`WEB_AUTH_CONFIG  `  | `web.auth-config`
+`WEB_AUTH_CONFIG`    | `web.auth.config`
 `WEB_LISTEN_ADDRESS` | `web.listen-address`
 `WEB_TELEMETRY_PATH` | `web.telemetry-path`
 

--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -12,7 +12,7 @@
 .Op Fl Fl rc-script
 .Nm
 .Op Fl Fl output.file-path Ns = Ns Ar path
-.Op Fl Fl web.auth-config Ns = Ns Ar path
+.Op Fl Fl web.auth.config Ns = Ns Ar path
 .Op Fl Fl web.listen-address Ns = Ns Ar addr:port
 .Op Fl Fl web.telemetry-path Ns = Ns Ar path
 .Nm
@@ -59,7 +59,7 @@ Giving a
 of
 .Dq Cm -
 will output collected metrics to stdout.
-.It Fl Fl web.auth-config Ns = Ns Ar path
+.It Fl Fl web.auth.config Ns = Ns Ar path
 Specify a
 .Ar path
 to load HTTP Basic Authentication configuration from.
@@ -201,7 +201,7 @@ is equivalent to setting the
 option.
 .It Ev WEB_AUTH_CONFIG
 is equivalent to setting the
-.Fl Fl web.auth-config
+.Fl Fl web.auth.config
 option.
 .It Ev WEB_LISTEN_ADDRESS
 is equivalent to setting the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,10 +26,10 @@ fn create_app() -> Command {
             Arg::new("OUTPUT_FILE_PATH")
                 .action(ArgAction::Set)
                 .env("OUTPUT_FILE_PATH")
+                .help("File to output metrics to.")
                 .hide_env_values(true)
                 .long("output.file-path")
                 .value_name("FILE")
-                .help("File to output metrics to.")
                 .value_parser(validator::is_valid_output_file_path)
         )
         .arg(
@@ -59,10 +59,11 @@ fn create_app() -> Command {
     let app = app.arg(
         Arg::new("WEB_AUTH_CONFIG")
             .action(ArgAction::Set)
+            .alias("web.auth-config")
             .env("WEB_AUTH_CONFIG")
             .help("Path to HTTP Basic Authentication configuration")
             .hide_env_values(true)
-            .long("web.auth-config")
+            .long("web.auth.config")
             .value_name("CONFIG")
             .value_parser(validator::is_valid_basic_auth_config_path)
     );
@@ -138,6 +139,9 @@ mod tests {
     use std::panic;
     use std::sync::LazyLock;
 
+    #[cfg(feature = "auth")]
+    use std::path::PathBuf;
+
     // Used during env_tests
     static LOCK: LazyLock<Mutex<i8>> = LazyLock::new(|| Mutex::new(0));
 
@@ -183,6 +187,36 @@ mod tests {
         let telemetry_path = matches.get_one::<String>("WEB_TELEMETRY_PATH");
 
         assert_eq!(telemetry_path, Some(&"/metrics".into()));
+    }
+
+    #[cfg(feature = "auth")]
+    #[test]
+    fn cli_set_web_auth_config() {
+        let argv = vec![
+            "jail_exporter",
+            "--web.auth.config=example-config.yaml",
+        ];
+
+        let matches = create_app().get_matches_from(argv);
+        let web_auth_config = matches.get_one::<PathBuf>("WEB_AUTH_CONFIG");
+
+        assert_eq!(web_auth_config, Some(&"example-config.yaml".into()));
+    }
+
+    // Tests that the hidden alias (the old name for this option) continues to
+    // set the web_auth_config correctly.
+    #[cfg(feature = "auth")]
+    #[test]
+    fn cli_set_web_auth_config_legacy() {
+        let argv = vec![
+            "jail_exporter",
+            "--web.auth-config=example-config.yaml",
+        ];
+
+        let matches = create_app().get_matches_from(argv);
+        let web_auth_config = matches.get_one::<PathBuf>("WEB_AUTH_CONFIG");
+
+        assert_eq!(web_auth_config, Some(&"example-config.yaml".into()));
     }
 
     #[test]

--- a/src/cli/validator.rs
+++ b/src/cli/validator.rs
@@ -11,15 +11,15 @@ use tracing::debug;
 use std::path::PathBuf;
 
 #[cfg(feature = "auth")]
-// Basic checks for valid filesystem path for web.auth-config existing.
+// Basic checks for valid filesystem path for web.auth.config existing.
 pub fn is_valid_basic_auth_config_path(s: &str) -> Result<PathBuf, String> {
-    debug!("Ensuring that web.auth-config is valid");
+    debug!("Ensuring that web.auth.config is valid");
 
     // Get a Path from our string and start checking
     let path = Path::new(&s);
 
     if !path.is_file() {
-        return Err("web.auth-config doesn't doesn't exist".to_owned());
+        return Err("web.auth.config doesn't doesn't exist".to_owned());
     }
 
     Ok(path.to_path_buf())

--- a/src/httpd/handlers.rs
+++ b/src/httpd/handlers.rs
@@ -71,9 +71,11 @@ mod tests {
         routing::get,
         Router,
     };
-    use crate::httpd::BasicAuthConfig;
     use pretty_assertions::assert_eq;
     use tower::ServiceExt;
+
+    #[cfg(feature = "auth")]
+    use crate::httpd::BasicAuthConfig;
 
     fn app(state: Arc<AppState>) -> Router {
         Router::new()


### PR DESCRIPTION
This argument was inconsistent with other Prometheus exporters, so we have changed it to match.

This is not a breaking change, as the old `--web.auth-config` is an alias for this new argument and will continue to work.

A couple of tests were added to verify that both the old and new names for the argument correctly set the `WEB_AUTH_CONFIG` file.

This commit also:
  - Enables the `error-context` feature in clap, which allows our own error messages to be shown when CLI validation fails
  - Fixes "auth" feature related includes to allow tests without default features to run correctly

Fixes: #289 