### PR TITLE
cli: Improve --web.listen-address argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
       alias for `--web.auth.config`, so this is not a breaking change
   - Fix error messages by including the clap `error-context` feature
   - Minor fixes to tests when not using default crate features
+  - `--web.listen-address` can now take just a port with no address in the
+    format of `:9452`
 
 ## v0.18.0
 

--- a/man/jail_exporter.8
+++ b/man/jail_exporter.8
@@ -82,6 +82,11 @@ If specifying an IPv6
 .Ar addr:port
 the address portion should be enclosed within square brackets, for example:
 .Dq Cm [::1]:9452 .
+It is also possible to just specify a port in the format of
+.Ar :port
+which will result in
+.Nm
+listening on all interfaces on the given port.
 .It Fl Fl web.telemetry-path Ns = Ns Ar path
 Specify a
 .Ar path

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,6 +233,19 @@ mod tests {
     }
 
     #[test]
+    fn cli_set_web_listen_address_without_address() {
+        let argv = vec![
+            "jail_exporter",
+            "--web.listen-address=:9452",
+        ];
+
+        let matches = create_app().get_matches_from(argv);
+        let web_listen_address = matches.get_one::<String>("WEB_LISTEN_ADDRESS");
+
+        assert_eq!(web_listen_address, Some(&"[::]:9452".into()));
+    }
+
+    #[test]
     fn cli_override_env_web_listen_address() {
         env_test("WEB_LISTEN_ADDRESS", "127.0.1.2:9452", || {
             let argv = vec![

--- a/src/cli/validator.rs
+++ b/src/cli/validator.rs
@@ -130,8 +130,17 @@ pub fn is_valid_password(s: &str) -> Result<String, String> {
 pub fn is_valid_socket_addr(s: &str) -> Result<String, String> {
     debug!("Ensuring that web.listen-address is valid");
 
-    match SocketAddr::from_str(s) {
-        Ok(_)  => Ok(s.to_string()),
+    // If the socker addr begins with : assume we just got a port and prefix it
+    // with [::].
+    let addr = if s.starts_with(':') {
+        format!("[::]{s}")
+    }
+    else {
+        s.to_string()
+    };
+
+    match SocketAddr::from_str(&addr) {
+        Ok(_)  => Ok(addr),
         Err(_) => Err(format!("'{s}' is not a valid ADDR:PORT string")),
     }
 }
@@ -215,13 +224,19 @@ mod tests {
     #[test]
     fn is_valid_socket_addr_ipv4_with_port() {
         let res = is_valid_socket_addr("127.0.0.1:9452");
-        assert!(res.is_ok());
+        assert_eq!(res, Ok("127.0.0.1:9452".to_string()));
     }
 
     #[test]
     fn is_valid_socket_addr_ipv6_with_port() {
         let res = is_valid_socket_addr("[::1]:9452");
-        assert!(res.is_ok());
+        assert_eq!(res, Ok("[::1]:9452".to_string()));
+    }
+
+    #[test]
+    fn is_valid_socket_addr_without_address() {
+        let res = is_valid_socket_addr(":9452");
+        assert_eq!(res, Ok("[::]:9452".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
The argument can now take just a port prepended with a `:`, such as `:9452`.

In this case, the bare port will be prepended with `[::]`, resulting in the string `[::]:9452`.

We also improve the tests in this area by making sure that the returned result is what we expect, rather than just looking for an `Ok`.

This will fix #290 