### PR TITLE
Fix manlint in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,23 +7,7 @@ on:
       - 'main'
   pull_request:
 
-# Main test jobs are via CirrusCI as we need FreeBSD runners.
 jobs:
-  mandoc:
-    name: 'Lint Man Page'
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@v4'
-        with:
-          fetch-depth: 1
-      - name: 'Install mandoc'
-        run: |
-          sudo apt install mandoc
-      - name: 'Lint man page'
-        run: |
-          make manlint
-
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -53,3 +37,6 @@ jobs:
       - name: Clippy
         shell: freebsd {0}
         run: cargo clippy --all-targets
+      - name: mandoc
+        shell: freebsd {0}
+        run: make manlint


### PR DESCRIPTION
It needs to run on FreeBSD so the cross-references will be available.